### PR TITLE
Initialize Wstat Dir per 9p public spec.

### DIFF
--- a/p/p9.go
+++ b/p/p9.go
@@ -533,7 +533,13 @@ func (err *Error) Error() string {
 // something. It will be correct for both 9p2000
 // and 9p2000.u
 func NewWstatDir() *Dir {
+	// Ignore Size, and 9p servers should too,
+	// because this field isn't kept in tact: a
+	// maximal value is truncated.
 	return &Dir{
+		Type:    ^uint16(0),
+		Dev:     ^uint32(0),
+		Qid:     Qid{Type: ^uint8(0), Version: ^uint32(0), Path: ^uint64(0)},
 		Mode:    ^uint32(0),
 		Length:  ^uint64(0),
 		Atime:   ^uint32(0),


### PR DESCRIPTION
According to the public 9p documentation, if Type, Dev, Qid, Atime
are not "don't touch", then the server must reject the Wstat request
and return an error.  To allow FSync to succeed, we need to initialize
these fields properly with don't touch values.