### PR TITLE
Remove data races.

### DIFF
--- a/p/clnt/clnt.go
+++ b/p/clnt/clnt.go
@@ -224,18 +224,23 @@ func (clnt *Clnt) recv() {
 			}
 
 			r.Rc = fc
-			if r.prev != nil {
-				r.prev.next = r.next
-				r.prev = nil
-			} else {
-				clnt.reqfirst = r.next
-			}
-
-			if r.next != nil {
-				r.next.prev = r.prev
-				r.next = nil
-			} else {
+			switch {
+			case r.next == nil && r.prev == nil:
+				clnt.reqlast = nil
+				clnt.reqfirst = nil
+			case r.next == nil:
 				clnt.reqlast = r.prev
+				r.prev.next = nil
+				r.prev = nil
+			case r.prev == nil:
+				clnt.reqfirst = r.next
+				r.next.prev = nil
+				r.next = nil
+			default:
+				r.next.prev = r.prev
+				r.prev.next = r.next
+				r.next = nil
+				r.prev = nil
 			}
 			clnt.Unlock()
 

--- a/p/srv/fcall.go
+++ b/p/srv/fcall.go
@@ -331,6 +331,7 @@ func (srv *Srv) read(req *Req) {
 	}
 
 	if (fid.Type & p.QTDIR) != 0 {
+		fid.Lock()
 		if tc.Offset == 0 {
 			fid.Diroffset = 0
 		} else if tc.Offset != fid.Diroffset {
@@ -342,6 +343,7 @@ func (srv *Srv) read(req *Req) {
 			// the provider decide if this is an error.
 			fid.Diroffset = tc.Offset
 		}
+		fid.Unlock()
 	}
 
 	(req.Conn.Srv.ops).(ReqOps).Read(req)
@@ -349,7 +351,9 @@ func (srv *Srv) read(req *Req) {
 
 func (srv *Srv) readPost(req *Req) {
 	if req.Rc != nil && req.Rc.Type == p.Rread && (req.Fid.Type&p.QTDIR) != 0 {
+		req.Fid.Lock()
 		req.Fid.Diroffset += uint64(req.Rc.Count)
+		req.Fid.Unlock()
 	}
 }
 

--- a/p/srv/file.go
+++ b/p/srv/file.go
@@ -411,9 +411,9 @@ func (*Fsrv) Read(req *Req) {
 
 	if f.Mode&p.DMDIR != 0 {
 		// directory
+		f.Lock()
 		if tc.Offset == 0 {
 			var g *File
-			f.Lock()
 			for n, g = 0, f.cfirst; g != nil; n, g = n+1, g.next {
 			}
 
@@ -421,7 +421,6 @@ func (*Fsrv) Read(req *Req) {
 			for n, g = 0, f.cfirst; g != nil; n, g = n+1, g.next {
 				fid.dirs[n] = g
 			}
-			f.Unlock()
 		}
 
 		n = 0
@@ -446,6 +445,7 @@ func (*Fsrv) Read(req *Req) {
 			n += len(nd)
 		}
 		fid.dirs = fid.dirs[i:]
+		f.Unlock()
 	} else {
 		// file
 		if rop, ok := f.Ops.(FReadOp); ok {


### PR DESCRIPTION
This removes data detector conditions that I saw with basic testing.

I run many concurrent Read() requests (on the root directory node) with the ramfs server.