### PR TITLE
Check that a fid has been opened in read, similar to write.

### DIFF
--- a/p/srv/fcall.go
+++ b/p/srv/fcall.go
@@ -330,6 +330,11 @@ func (srv *Srv) read(req *Req) {
 		return
 	}
 
+	if !fid.opened || (fid.Omode&3) == p.OWRITE {
+		req.RespondError(Ebaduse)
+		return
+	}
+
 	if (fid.Type & p.QTDIR) != 0 {
 		fid.Lock()
 		if tc.Offset == 0 {


### PR DESCRIPTION
Right now the the check for whether a fid is opened is only
necessary on servicing a Tread.  Let's be consistent.