### PR TITLE
p/srv: prevent double encoding of errno

### DIFF
--- a/p/srv/respond.go
+++ b/p/srv/respond.go
@@ -11,7 +11,7 @@ import "github.com/lionkov/go9p/p"
 func (req *Req) RespondError(err interface{}) {
 	switch e := err.(type) {
 	case *p.Error:
-		p.PackRerror(req.Rc, e.Error(), uint32(e.Errornum), req.Conn.Dotu)
+		p.PackRerror(req.Rc, e.Err, uint32(e.Errornum), req.Conn.Dotu)
 	case error:
 		p.PackRerror(req.Rc, e.Error(), uint32(p.EIO), req.Conn.Dotu)
 	default:


### PR DESCRIPTION
this one is a little less clear-cut.

right now when encoding Rerrors, a *p.Error is stringified, which puts a string of the errno on the end. when using 9p2000.u, this information is redundant and less parseable, but when using 9p2000, some might argue that having the stringified errno is valueable.

my reasoning for this change is writing integration tests which compare errors. without this change, what the server sends and what the client sees differ by the stringified errno.

i personally am in favor of eliding the stringified errno. if somebody wanted to know errnos while not using 9p2000.u, they can log it server side.